### PR TITLE
Change standard shell to `bash`

### DIFF
--- a/icinga-diagnostics.sh
+++ b/icinga-diagnostics.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # Icinga Diagnostics
 # Collect basic data about your Icinga 2 installation
 # maintainer: Thomas Widhalm <thomas.widhalm@icinga.com>


### PR DESCRIPTION
While we tried hard to stay compatible to `sh`, there are some features that force the use of `bash`. We could work around them but since there are at least two projects trying to create either a new version of Icinga Diagnostics or a replacement tool I don't want to put all too much effort into the current version and try to fix as many open issues as possible in a not too much time consuming way.

Fixes #94